### PR TITLE
Updated demo link to latest location

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Libris
 
-A documentation theme for Stackbit. [Live Demo](https://themes.stackbit.com/demos/libris)
+A documentation theme for Stackbit. [Live Demo](https://themes.stackbit.com/demos/libris/blue/)
 
 Click the button below to use this theme in Gatsby, Hugo or Jekyll via the Stackbit site builder:
 


### PR DESCRIPTION
The [previous link](https://themes.stackbit.com/demos/libris) in README.md was now pointing to a 404 page. The link was replaced by [the demo location](https://themes.stackbit.com/demos/libris/blue/) provided on stackbit.com.